### PR TITLE
Build uCsim on Linux using Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: Build uCsim
+on: [push]
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          ./config_linux.sh
+          make
+          cd picsimlab
+          make


### PR DESCRIPTION
This adds a Github Action building uCsim+picsimlab-specifics on Linux. 

Github Actions are [free](https://docs.github.com/en/enterprise-cloud@latest/billing/managing-billing-for-github-actions/about-billing-for-github-actions) for public repositories.

Actions are set up to run on every push.

Example of action running on [my fork](https://github.com/hsorbo/uCsim_picsimlab/actions/runs/2144150891)